### PR TITLE
fix 注册用户时中文长度bug 

### DIFF
--- a/common.php
+++ b/common.php
@@ -494,7 +494,7 @@ function IsJson($String)
 //判断是否为合法用户名
 function IsName($string)
 {
-	return !preg_match('/^[0-9]{4,20}$/', $string) && preg_match('/^[a-zA-Z0-9\x80-\xff\-_]{4,20}$/i', $string);
+	return !preg_match('/^[0-9]{4,20}$/', $string) && preg_match('/^[a-zA-Z0-9\x{4e00}-\x{9fa5}\-_]{4,20}$/ui', $string);
 }
 
 


### PR DESCRIPTION
注册用户时， 中文长度目前最多是6个汉字，和期望的4-20不符

修正正则表达式