### PR TITLE
获取通知接口严重占用fpm进程。。

### DIFF
--- a/controller/json.php
+++ b/controller/json.php
@@ -4,39 +4,34 @@ SetStyle('api', 'API');
 switch (Request('Request', 'action')) {
 	case 'get_notifications':
 		Auth(1);
-		header("Cache-Control: no-cache, must-revalidate");
-		@set_time_limit(0);
+		// header("Cache-Control: no-cache, must-revalidate");
+		// @set_time_limit(0);
 		//如果是自己的服务器，建议调大超时时间，然后把长连接时长调大，以节约服务器资源
-		$Config['PushConnectionTimeoutPeriod'] = intval((intval($Config['PushConnectionTimeoutPeriod']) < 22) ? 22 : $Config['PushConnectionTimeoutPeriod']);
-		while ((time() - $TimeStamp) < $Config['PushConnectionTimeoutPeriod']) {
-			if ($MCache) {
-				$CurUserInfo = $MCache->get(MemCachePrefix . 'UserInfo_' . $CurUserID);
-				if ($CurUserInfo) {
-					$CurNewNotification = $CurUserInfo['NewNotification'];
-				} else {
-					$TempUserInfo = $DB->row("SELECT *, (NewReply + NewMention + NewMessage) as NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
-						"UserID" => $CurUserID
-					));
-					$MCache->set(MemCachePrefix . 'UserInfo_' . $CurUserID, $TempUserInfo, 86400);
-					$CurNewNotification = $TempUserInfo['NewNotification'];
-				}
-			} else {
-				$CurNewNotification = $DB->single("SELECT (NewReply + NewMention + NewMessage) AS NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
-					"UserID" => $CurUserID
-				));
-			}
-			
-			if ($CurNewNotification > 0) {
-				break;
-			}
-			sleep(3);
-		}
+		// $Config['PushConnectionTimeoutPeriod'] = intval((intval($Config['PushConnectionTimeoutPeriod']) < 22) ? 22 : $Config['PushConnectionTimeoutPeriod']);
+
+        if ($MCache) {
+            $CurUserInfo = $MCache->get(MemCachePrefix . 'UserInfo_' . $CurUserID);
+            if ($CurUserInfo) {
+                $CurNewNotification = $CurUserInfo['NewNotification'];
+            } else {
+                $TempUserInfo = $DB->row("SELECT *, (NewReply + NewMention + NewMessage) as NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
+                    "UserID" => $CurUserID
+                ));
+                $MCache->set(MemCachePrefix . 'UserInfo_' . $CurUserID, $TempUserInfo, 86400);
+                $CurNewNotification = $TempUserInfo['NewNotification'];
+            }
+        } else {
+            $CurNewNotification = $DB->single("SELECT (NewReply + NewMention + NewMessage) AS NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
+                "UserID" => $CurUserID
+            ));
+        }
+
 		echo json_encode(array(
 			'Status' => 1,
 			'NewMessage' => $CurNewNotification
 		));
 		break;
-	
+
 	
 	case 'get_tags':
 		Auth(1);

--- a/controller/json.php
+++ b/controller/json.php
@@ -4,27 +4,22 @@ SetStyle('api', 'API');
 switch (Request('Request', 'action')) {
 	case 'get_notifications':
 		Auth(1);
-		// header("Cache-Control: no-cache, must-revalidate");
-		// @set_time_limit(0);
-		//如果是自己的服务器，建议调大超时时间，然后把长连接时长调大，以节约服务器资源
-		// $Config['PushConnectionTimeoutPeriod'] = intval((intval($Config['PushConnectionTimeoutPeriod']) < 22) ? 22 : $Config['PushConnectionTimeoutPeriod']);
-
-        if ($MCache) {
-            $CurUserInfo = $MCache->get(MemCachePrefix . 'UserInfo_' . $CurUserID);
-            if ($CurUserInfo) {
-                $CurNewNotification = $CurUserInfo['NewNotification'];
-            } else {
-                $TempUserInfo = $DB->row("SELECT *, (NewReply + NewMention + NewMessage) as NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
-                    "UserID" => $CurUserID
-                ));
-                $MCache->set(MemCachePrefix . 'UserInfo_' . $CurUserID, $TempUserInfo, 86400);
-                $CurNewNotification = $TempUserInfo['NewNotification'];
-            }
-        } else {
-            $CurNewNotification = $DB->single("SELECT (NewReply + NewMention + NewMessage) AS NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
-                "UserID" => $CurUserID
-            ));
-        }
+		if ($MCache) {
+			$CurUserInfo = $MCache->get(MemCachePrefix . 'UserInfo_' . $CurUserID);
+			if ($CurUserInfo) {
+				$CurNewNotification = $CurUserInfo['NewNotification'];
+			} else {
+				$TempUserInfo = $DB->row("SELECT *, (NewReply + NewMention + NewMessage) as NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
+					"UserID" => $CurUserID
+				));
+				$MCache->set(MemCachePrefix . 'UserInfo_' . $CurUserID, $TempUserInfo, 86400);
+				$CurNewNotification = $TempUserInfo['NewNotification'];
+			}
+		} else {
+			$CurNewNotification = $DB->single("SELECT (NewReply + NewMention + NewMessage) AS NewNotification FROM " . PREFIX . "users WHERE ID = :UserID", array(
+				"UserID" => $CurUserID
+			));
+		}
 
 		echo json_encode(array(
 			'Status' => 1,


### PR DESCRIPTION
搭了个内网用的，发现多人访问时响应超时，分钟级别。
重启fpm后前几个请求速度正常，逐渐访问之后响应时间逐渐累加

ps： 个人设置fpm进程数10

看了看逻辑，这个获取通知的接口是长连接去轮询，最长要22秒，这会占用一个fpm进程22秒的时间。。
即使我开100个fpm进程，那么100个人同时访问的话，那这100个fpm进程全部被阻塞，下一个人请求主页的时候就会卡主，，直到22秒以后，有fpm进程被释放。
即使我并发不是100， 是10，那么每次请求会消耗10个fpm进程，这10个人刷10次，论坛基本就挂了，因为这时候新人访问的话没有fpm进程去处理。

说了这么多，就是想表达，在http server中千万不要加类似sleep的逻辑，这会严重影响服务器的吞吐量。。类似的通知机制你可以浏览器setinterval轮询，或者建立websocket长连接，千万别直接sleep占用进程数。

【这也是为什么你论坛上别人说很慢，你访问却秒开的原因，因为你访问的时候他们的服务器已经处理完所有22秒的请求，基本处于空闲状态。这时候如果你浏览器多刷新几次他们的网页，一样会变慢。】