### PR TITLE
使用utf8mb4作为默认字符集

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A high performance open-source forum software written in PHP.
 
 * PHP version 5.4.0 or higher.
 * The [__PDO_MYSQL__](http://php.net/manual/en/ref.pdo-mysql.php) PHP Package.
-* MySQL version 5.0 or higher.
+* MySQL version 5.5.3 or higher.
 * The [__mod_rewrite__](http://httpd.apache.org/docs/2.2/mod/mod_rewrite.html) Apache module / [__ngx_http_rewrite_module__](https://github.com/lincanbin/Carbon-Forum/blob/master/nginx.conf) / [__ISAPI_Rewrite__](http://www.helicontech.com/isapi_rewrite/) IIS module / IIS7+. 
 * The [__mod_headers__](http://httpd.apache.org/docs/2.2/mod/mod_headers.html) module is needed if you run Carbon Forum on Apache HTTP Server.
 

--- a/docker_resources/sphinx.conf
+++ b/docker_resources/sphinx.conf
@@ -12,7 +12,7 @@ source kms_db
 	sql_db			= knowledge
 	sql_port		= 3306	# optional, default is 3306
 
-    sql_query_pre   = SET NAMES utf8
+    sql_query_pre   = SET NAMES utf8mb4
 
 
 	sql_query		= \

--- a/install/database.sql
+++ b/install/database.sql
@@ -25,7 +25,7 @@ CREATE TABLE `carbon_app` (
   `Time` int(10) unsigned NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `AppKey` (`AppKey`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_app_users
@@ -35,13 +35,13 @@ CREATE TABLE `carbon_app_users` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `AppID` int(10) unsigned NOT NULL,
   `OpenID` varchar(64) NOT NULL,
-  `AppUserName` varchar(50) CHARACTER SET utf8,
+  `AppUserName` varchar(50),
   `UserID` int(10) unsigned NOT NULL,
   `Time` int(10) unsigned NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `Index` (`AppID`,`OpenID`),
   KEY `UserID` (`UserID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_config
@@ -51,7 +51,7 @@ CREATE TABLE `carbon_config` (
   `ConfigName` varchar(50) NOT NULL DEFAULT '',
   `ConfigValue` text NOT NULL,
   PRIMARY KEY (`ConfigName`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_dict
@@ -62,8 +62,8 @@ CREATE TABLE `carbon_dict` (
   `Title` varchar(512) NOT NULL,
   `Abstract` mediumtext NOT NULL,
   PRIMARY KEY (`ID`),
-  KEY `title` (`Title`(200)) USING HASH
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+  KEY `title` (`Title`(190)) USING HASH
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_favorites
@@ -72,16 +72,16 @@ DROP TABLE IF EXISTS `carbon_favorites`;
 CREATE TABLE `carbon_favorites` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `UserID` int(10) unsigned NOT NULL,
-  `Category` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Title` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `Category` varchar(255) DEFAULT NULL,
+  `Title` varchar(255) DEFAULT NULL,
   `Type` tinyint(1) unsigned DEFAULT NULL,
   `FavoriteID` int(10) unsigned NOT NULL,
   `DateCreated` int(10) unsigned NOT NULL,
-  `Description` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `Description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `IsFavorite` (`UserID`,`Type`,`FavoriteID`),
   KEY `UsersFavorites` (`UserID`,`Type`,`DateCreated`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_inbox
@@ -100,7 +100,7 @@ CREATE TABLE `carbon_inbox` (
   KEY `DialogueID` (`LastTime`) USING BTREE,
   KEY `SenderID` (`SenderID`,`ReceiverID`),
   KEY `ReceiverID` (`ReceiverID`,`SenderID`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_link
@@ -108,14 +108,14 @@ CREATE TABLE `carbon_inbox` (
 DROP TABLE IF EXISTS `carbon_link`;
 CREATE TABLE `carbon_link` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `Name` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `URL` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Logo` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Intro` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `Name` varchar(255) DEFAULT NULL,
+  `URL` varchar(255) DEFAULT NULL,
+  `Logo` varchar(255) DEFAULT NULL,
+  `Intro` varchar(255) DEFAULT NULL,
   `Review` int(11) DEFAULT '0',
   `TopLink` int(11) DEFAULT '0',
   PRIMARY KEY (`ID`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_messages
@@ -130,7 +130,7 @@ CREATE TABLE `carbon_messages` (
   `IsDel` tinyint(3) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`ID`),
   KEY `Index` (`IsDel`,`InboxID`,`Time`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_notifications
@@ -149,7 +149,7 @@ CREATE TABLE `carbon_notifications` (
   KEY `TopicID` (`TopicID`),
   KEY `PostID` (`PostID`),
   KEY `UserID` (`UserID`,`Time`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_posts
@@ -160,16 +160,16 @@ CREATE TABLE `carbon_posts` (
   `TopicID` int(10) unsigned DEFAULT '0',
   `IsTopic` tinyint(1) unsigned DEFAULT '0',
   `UserID` int(10) unsigned NOT NULL,
-  `UserName` varchar(50) CHARACTER SET utf8 NOT NULL,
-  `Subject` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Content` longtext CHARACTER SET utf8,
-  `PostIP` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
+  `UserName` varchar(50) NOT NULL,
+  `Subject` varchar(255) DEFAULT NULL,
+  `Content` longtext,
+  `PostIP` varchar(50) DEFAULT NULL,
   `PostTime` int(10) unsigned NOT NULL,
   `PostTimeIndex` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`ID`),
   KEY `TopicID` (`TopicID`,`PostTimeIndex`) USING BTREE,
   KEY `UserPosts` (`UserName`,`PostTimeIndex`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_posts_recycle_bin
@@ -189,7 +189,7 @@ CREATE TABLE `carbon_posts_recycle_bin` (
   PRIMARY KEY (`ID`),
   KEY `TopicID` (`TopicID`,`PostTimeIndex`) USING BTREE,
   KEY `UserPosts` (`UserName`,`PostTimeIndex`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_posttags
@@ -201,7 +201,7 @@ CREATE TABLE `carbon_posttags` (
   `PostID` int(11) DEFAULT '0',
   KEY `TagsIndex` (`TagID`,`TopicID`),
   KEY `TopicID` (`TopicID`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_statistics
@@ -217,7 +217,7 @@ CREATE TABLE `carbon_statistics` (
   `DaysDate` date NOT NULL DEFAULT '2014-11-01',
   `DateCreated` int(10) unsigned NOT NULL,
   PRIMARY KEY (`DaysDate`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_tags
@@ -225,18 +225,18 @@ CREATE TABLE `carbon_statistics` (
 DROP TABLE IF EXISTS `carbon_tags`;
 CREATE TABLE `carbon_tags` (
   `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `Name` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `Name` varchar(255) NOT NULL,
   `Followers` int(10) unsigned DEFAULT '0',
   `Icon` tinyint(1) unsigned DEFAULT '0',
-  `Description` mediumtext CHARACTER SET utf8,
+  `Description` mediumtext,
   `IsEnabled` tinyint(1) unsigned DEFAULT '1',
   `TotalPosts` int(10) unsigned DEFAULT '0',
   `MostRecentPostTime` int(10) unsigned NOT NULL,
   `DateCreated` int(10) unsigned NOT NULL,
   PRIMARY KEY (`ID`),
-  KEY `TagName` (`Name`) USING HASH,
+  KEY `TagName` (`Name`(190)) USING HASH,
   KEY `TotalPosts` (`IsEnabled`, `TotalPosts`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_topics
@@ -244,11 +244,11 @@ CREATE TABLE `carbon_tags` (
 DROP TABLE IF EXISTS `carbon_topics`;
 CREATE TABLE `carbon_topics` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
-  `Topic` varchar(255) CHARACTER SET utf8 NOT NULL,
-  `Tags` text CHARACTER SET utf8,
+  `Topic` varchar(255) NOT NULL,
+  `Tags` text,
   `UserID` int(10) unsigned NOT NULL DEFAULT '0',
-  `UserName` varchar(50) CHARACTER SET utf8 NOT NULL,
-  `LastName` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
+  `UserName` varchar(50) NOT NULL,
+  `LastName` varchar(50) DEFAULT NULL,
   `PostTime` int(10) unsigned NOT NULL,
   `LastTime` int(10) unsigned NOT NULL,
   `LastTimeIndex` bigint(20) unsigned NOT NULL DEFAULT '0',
@@ -261,7 +261,7 @@ CREATE TABLE `carbon_topics` (
   PRIMARY KEY (`ID`),
   KEY `LastTime` (`LastTimeIndex`,`IsDel`) USING BTREE,
   KEY `UserTopics` (`UserName`,`IsDel`,`LastTimeIndex`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_upload
@@ -269,23 +269,23 @@ CREATE TABLE `carbon_topics` (
 DROP TABLE IF EXISTS `carbon_upload`;
 CREATE TABLE `carbon_upload` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
-  `UserName` varchar(50) CHARACTER SET utf8 NOT NULL,
-  `FileName` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `UserName` varchar(50) NOT NULL,
+  `FileName` varchar(255) NOT NULL,
   `FileSize` int(10) unsigned NOT NULL DEFAULT '0',
-  `FileType` varchar(255) CHARACTER SET utf8 NOT NULL,
+  `FileType` varchar(255) NOT NULL,
   `SHA1` char(40) DEFAULT NULL,
   `MD5` char(32) DEFAULT NULL,
-  `FilePath` varchar(255) CHARACTER SET utf8 NOT NULL,
-  `Description` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Category` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `Class` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
+  `FilePath` varchar(255) NOT NULL,
+  `Description` varchar(255) DEFAULT NULL,
+  `Category` varchar(255) DEFAULT NULL,
+  `Class` varchar(255) DEFAULT NULL,
   `PostID` int(10) unsigned DEFAULT NULL,
   `Created` int(10) unsigned NOT NULL,
   PRIMARY KEY (`ID`),
   KEY `Hash` (`FileSize`,`SHA1`,`MD5`) USING BTREE,
   KEY `UsersName` (`UserName`,`Created`) USING BTREE,
   KEY `PostID` (`PostID`,`UserName`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Table structure for carbon_users
@@ -293,13 +293,13 @@ CREATE TABLE `carbon_upload` (
 DROP TABLE IF EXISTS `carbon_users`;
 CREATE TABLE `carbon_users` (
   `ID` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `UserName` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
+  `UserName` varchar(50) DEFAULT NULL,
   `Salt` int(6) unsigned DEFAULT NULL,
-  `Password` char(32) CHARACTER SET utf8 DEFAULT NULL,
-  `UserMail` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `UserHomepage` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `PasswordQuestion` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `PasswordAnswer` char(32) CHARACTER SET utf8 DEFAULT NULL,
+  `Password` char(32) DEFAULT NULL,
+  `UserMail` varchar(255) DEFAULT NULL,
+  `UserHomepage` varchar(255) DEFAULT NULL,
+  `PasswordQuestion` varchar(255) DEFAULT NULL,
+  `PasswordAnswer` char(32) DEFAULT NULL,
   `UserSex` tinyint(1) unsigned DEFAULT NULL,
   `NumFavUsers` int(10) unsigned DEFAULT '0',
   `NumFavTags` int(10) unsigned DEFAULT '0',
@@ -312,23 +312,23 @@ CREATE TABLE `carbon_users` (
   `Followers` int(10) unsigned DEFAULT '0',
   `DelTopic` int(10) unsigned DEFAULT '0',
   `GoodTopic` int(10) unsigned DEFAULT '0',
-  `UserPhoto` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `UserMobile` varchar(255) CHARACTER SET utf8 DEFAULT NULL,
-  `UserLastIP` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
+  `UserPhoto` varchar(255) DEFAULT NULL,
+  `UserMobile` varchar(255) DEFAULT NULL,
+  `UserLastIP` varchar(50) DEFAULT NULL,
   `UserRegTime` int(10) unsigned NOT NULL,
   `LastLoginTime` int(10) unsigned NOT NULL,
   `LastPostTime` int(10) unsigned DEFAULT NULL,
-  `BlackLists` longtext CHARACTER SET utf8,
-  `UserFriend` longtext CHARACTER SET utf8,
-  `UserInfo` longtext CHARACTER SET utf8,
-  `UserIntro` longtext CHARACTER SET utf8,
-  `UserIM` longtext CHARACTER SET utf8,
+  `BlackLists` longtext,
+  `UserFriend` longtext,
+  `UserInfo` longtext,
+  `UserIntro` longtext,
+  `UserIM` longtext,
   `UserRoleID` tinyint(1) unsigned NOT NULL DEFAULT '3',
   `UserAccountStatus` tinyint(1) unsigned NOT NULL DEFAULT '1',
   `Birthday` date DEFAULT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `UserName` (`UserName`) USING HASH
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
 
 -- ----------------------------
 -- Records of carbon_config

--- a/update/index.php
+++ b/update/index.php
@@ -205,6 +205,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 	if (VersionCompare('6.0.0', $OldVersion)) {
 		$DB->beginTransaction();
 		try {
+			$Mb4MigrationQueries = Db::GetSqlQueriesFromFile(__DIR__ . '/migrate_utf8mb4.sql');
+			foreach ($Mb4MigrationQueries as $Query) {	
+				$DB->query($Query);
+			}
+			
 			$DB->query("DROP TABLE IF EXISTS `" . DATABASE_PREFIX . "blogs`;");
 			$DB->query("DROP TABLE IF EXISTS `" . DATABASE_PREFIX . "blogsettings`;");
 			$DB->query("DROP TABLE IF EXISTS `" . DATABASE_PREFIX . "vote`;");
@@ -253,7 +258,7 @@ ADD INDEX `UserTopics` (`UserName`, `IsDel`, `LastTimeIndex`) USING BTREE ;");
 			  PRIMARY KEY (`ID`),
 			  KEY `TopicID` (`TopicID`,`PostTimeIndex`) USING BTREE,
 			  KEY `UserPosts` (`UserName`,`PostTimeIndex`) USING BTREE
-			) ENGINE=InnoDB DEFAULT CHARSET=utf8;");
+			) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
 			$DB->query("UPDATE `" . DATABASE_PREFIX . "posts`
 				SET `PostTimeIndex` = CONV(
 					CONCAT(

--- a/update/migrate_utf8mb4.sql
+++ b/update/migrate_utf8mb4.sql
@@ -1,0 +1,129 @@
+---------------------------------------------------------
+-- Created based on /install/database.sql @ version 5.9.0
+---------------------------------------------------------
+
+-- Some key lengths need to be lowered
+-- because utf8mb4 may have 4-bytes max per character.
+-- Max key length is 767 bytes
+ALTER TABLE `carbon_dict` DROP KEY `title`;
+ALTER TABLE `carbon_dict` ADD KEY `title` (`Title`(190)) USING HASH;
+ALTER TABLE `carbon_tags` DROP KEY `TagName`;
+ALTER TABLE `carbon_tags` ADD KEY `TagName` (`Name`(190)) USING HASH;
+
+-- Change all utf8 columns to utf8mb4
+ALTER TABLE `carbon_app_users`
+  MODIFY COLUMN `AppUserName` varchar(50) CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_blogs`
+  MODIFY COLUMN `Content` longtext CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Category` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Subject` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlogDate` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_blogsettings`
+  MODIFY COLUMN `BlogTitle` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlogTagline` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `BlogBgcolor` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlogPermissions` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlogBackground` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlogAudio` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `MusicUrl` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `MusicName` longtext CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_favorites`
+  MODIFY COLUMN `Category` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Title` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Description` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_link`
+  MODIFY COLUMN `Name` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `URL` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Logo` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Intro` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_log`
+  MODIFY COLUMN `UserName` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `IPAddress` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserAgent` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `HttpVerb` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `PathAndQuery` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `Referrer` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `ErrDescription` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `POSTData` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `Notes` longtext CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_pictures`
+  MODIFY COLUMN `PicUrl` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserName` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `PicReadme` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_postrating`
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL;
+ALTER TABLE `carbon_posts`
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Subject` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Content` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `PostIP` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_roles`
+  MODIFY COLUMN `Name` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Description` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_tags`
+  MODIFY COLUMN `Name` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Description` mediumtext CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_topics`
+  MODIFY COLUMN `Topic` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Tags` text CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `LastName` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `ThreadStyle` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Lists` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `Log` longtext CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_upload`
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `FileName` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `FileType` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `FilePath` varchar(255) CHARACTER SET utf8mb4 NOT NULL,
+  MODIFY COLUMN `Description` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Category` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Class` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL;
+ALTER TABLE `carbon_users`
+  MODIFY COLUMN `UserName` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `Password` char(32) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserMail` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserHomepage` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `PasswordQuestion` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `PasswordAnswer` char(32) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserPhoto` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserMobile` varchar(255) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `UserLastIP` varchar(50) CHARACTER SET utf8mb4 DEFAULT NULL,
+  MODIFY COLUMN `BlackLists` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserFriend` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserInfo` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserIntro` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `UserIM` longtext CHARACTER SET utf8mb4;
+ALTER TABLE `carbon_vote`
+  MODIFY COLUMN `Items` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `Result` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `BallotUserList` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `BallotIPList` longtext CHARACTER SET utf8mb4,
+  MODIFY COLUMN `BallotItemsList` longtext CHARACTER SET utf8mb4;
+
+-- Set all tables' default charset to utf8mb4
+ALTER TABLE `carbon_app` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_app_users` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_blogs` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_blogsettings` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_config` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_dict` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_favorites` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_link` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_log` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_notifications` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_pictures` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_postrating` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_posts` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_posttags` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_roles` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_statistics` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_tags` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_topics` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_upload` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_users` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_vote` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_messages` DEFAULT CHARSET=utf8mb4;
+ALTER TABLE `carbon_inbox` DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
希望数据库后端使用`utf8mb4`作为默认字符集，以便支持Emoji等。

修改的内容：
* `install/database.sql`中将所有表的默认字符集都设为`utf8mb4`，删除了列单独设置的字符集（沿用自动应该更好维护，万一要修改可以直接改表的默认字符集，不用把单独这些列另外改过来）；
* 因为更新用的SQL内容较多，写到php里看起来太长，所以加入了`update/migrate_utf8mb4.sql`，用于将旧的表和设置了字符集的列全都改成用`utf8mb4`字符集；
* 将`install/index.php`中读取SQL文件的函数移动到了`library/PDO.class.php`中，这样在`update/index.php`中也可以用它读取SQL文件；
* 最低MySQL版本需要提升至5.5.3。